### PR TITLE
Improve handling of randomness

### DIFF
--- a/dml/data.py
+++ b/dml/data.py
@@ -1,12 +1,13 @@
 from dataclasses import dataclass
 import requests
 import torch
-from torch.utils.data import DataLoader, Dataset
+from torch.utils.data import DataLoader, Dataset, Sampler
 from torchvision import datasets, transforms
 from typing import Any, List, Tuple, Optional, Union
 import os 
 import numpy as np
 import random
+from dml.utils import set_seed
 
 @dataclass
 class DatasetSpec:
@@ -21,15 +22,25 @@ class DatasetSpec:
     training_iterations: int = 1
     weight: float = 1.0  
 
+class DeterministicSampler(Sampler):
+    """
+    Sampler for a single shuffle at initialization to ensure consistency across validators
+    """
+    def __init__(self, n):
+        self.idx = torch.randperm(n).tolist()
+
+    def __iter__(self):
+        return iter(self.idx)
+
+    def __len__(self):
+        return len(self.idx)
+
 def seed_worker(worker_id):
     worker_seed = torch.initial_seed() % 2**32
     np.random.seed(worker_seed)
     random.seed(worker_seed)
 
-def get_mnist_loaders(
-    batch_size: int = 32,
-    num_workers: int = 2
-) -> Tuple[DataLoader, DataLoader]:
+def get_mnist_loaders(batch_size: int = 32, num_workers: int = 2, seed: int = 42) -> Tuple[DataLoader, DataLoader]:
     transform = transforms.Compose([
         transforms.ToTensor(),
         transforms.Normalize((0.1307,), (0.3081,))
@@ -47,30 +58,28 @@ def get_mnist_loaders(
         train=False,
         transform=transform
     )
+    set_seed(seed)
+    train_sampler = DeterministicSampler(len(train_dataset))
+    val_sampler = DeterministicSampler(len(val_dataset))
     
     return (
         DataLoader(
             train_dataset, 
             batch_size=batch_size, 
-            shuffle=True, 
             num_workers=num_workers, 
             worker_init_fn=seed_worker,
-            generator=torch.Generator().manual_seed(42)
+            sampler=train_sampler
         ),
         DataLoader(
             val_dataset, 
             batch_size=batch_size, 
-            shuffle=False, 
             num_workers=num_workers, 
             worker_init_fn=seed_worker,
-            generator=torch.Generator().manual_seed(42)
+            sampler=val_sampler
         )
     )
 
-def get_cifar10_loaders(
-    batch_size: int = 32,
-    num_workers: int = 2
-) -> Tuple[DataLoader, DataLoader]:
+def get_cifar10_loaders(batch_size: int = 32, num_workers: int = 2, seed: int = 42) -> Tuple[DataLoader, DataLoader]:
     transform = transforms.Compose([
         transforms.ToTensor(),
         transforms.Normalize((0.5, 0.5, 0.5), (0.5, 0.5, 0.5))
@@ -88,30 +97,28 @@ def get_cifar10_loaders(
         train=False,
         transform=transform
     )
+    set_seed(seed)
+    train_sampler = DeterministicSampler(len(train_dataset))
+    val_sampler = DeterministicSampler(len(val_dataset))
     
     return (
         DataLoader(
             train_dataset, 
             batch_size=batch_size, 
-            shuffle=True, 
             num_workers=num_workers, 
             worker_init_fn=seed_worker,
-            generator=torch.Generator().manual_seed(42)
+            sampler=train_sampler
         ),
         DataLoader(
             val_dataset, 
             batch_size=batch_size, 
-            shuffle=False, 
             num_workers=num_workers, 
             worker_init_fn=seed_worker,
-            generator=torch.Generator().manual_seed(42)
+            sampler=val_sampler
         )
     )
 
-def get_cifar100_loaders(
-    batch_size: int = 32,
-    num_workers: int = 2
-) -> Tuple[DataLoader, DataLoader]:
+def get_cifar100_loaders(batch_size: int = 32, num_workers: int = 2, seed: int = 42) -> Tuple[DataLoader, DataLoader]:
     transform = transforms.Compose([
         transforms.ToTensor(),
         transforms.Normalize(
@@ -132,23 +139,24 @@ def get_cifar100_loaders(
         train=False,
         transform=transform
     )
+    set_seed(seed)
+    train_sampler = DeterministicSampler(len(train_dataset))
+    val_sampler = DeterministicSampler(len(val_dataset))
     
     return (
         DataLoader(
             train_dataset, 
             batch_size=batch_size, 
-            shuffle=True, 
             num_workers=num_workers, 
-            worker_init_fn=seed_worker, 
-            generator=torch.Generator.manual_seed(42)
+            worker_init_fn=seed_worker,
+            sampler=train_sampler
         ),
         DataLoader(
             val_dataset, 
             batch_size=batch_size, 
-            shuffle=False, 
             num_workers=num_workers, 
             worker_init_fn=seed_worker,
-            generator=torch.Generator().manual_seed(42)
+            sampler=val_sampler
         )
     )
 
@@ -156,7 +164,8 @@ def get_imagenet_1k_loaders(
     data_dir: str = './data/imagenet',
     batch_size: int = 32,
     num_workers: int = 4,
-    image_size: int = 224
+    image_size: int = 224,
+    seed: int = 42,
 ) -> Tuple[DataLoader, DataLoader]:
     """
     ImageNet-1K data loaders with standard augmentation
@@ -193,28 +202,26 @@ def get_imagenet_1k_loaders(
         split='val',
         transform=val_transform
     )
+    set_seed(seed)
+    train_sampler = DeterministicSampler(len(train_dataset))
+    val_sampler = DeterministicSampler(len(val_dataset))
     
-    train_loader = DataLoader(
-        train_dataset,
-        batch_size=batch_size,
-        shuffle=True,
-        num_workers=num_workers,
-        pin_memory=True,
-        worker_init_fn=seed_worker,
-        generator=torch.Generator().manual_seed(42)
+    return (
+        DataLoader(
+            train_dataset, 
+            batch_size=batch_size, 
+            num_workers=num_workers, 
+            worker_init_fn=seed_worker,
+            sampler=train_sampler
+        ),
+        DataLoader(
+            val_dataset, 
+            batch_size=batch_size, 
+            num_workers=num_workers, 
+            worker_init_fn=seed_worker,
+            sampler=val_sampler
+        )
     )
-    
-    val_loader = DataLoader(
-        val_dataset,
-        batch_size=batch_size,
-        shuffle=False,
-        num_workers=num_workers,
-        pin_memory=True,
-        worker_init_fn=seed_worker,
-        generator=torch.Generator().manual_seed(42)
-    )
-    
-    return train_loader, val_loader
 
 class ShakespeareDataset(Dataset):
     def __init__(
@@ -258,7 +265,8 @@ def get_shakespeare_loaders(
     text_path: str = './data/shakespeare.txt',
     batch_size: int = 64,
     seq_length: int = 256,
-    num_workers: int = 1
+    num_workers: int = 1,
+    seed: int = 42,
 ) -> Tuple[DataLoader, DataLoader]:
     """
     Shakespeare dataset loaders for character-level language modeling
@@ -274,29 +282,29 @@ def get_shakespeare_loaders(
         seq_length=seq_length,
         train=False
     )
+    set_seed(seed)
+    train_sampler = DeterministicSampler(len(train_dataset))
+    val_sampler = DeterministicSampler(len(val_dataset))
     
     train_loader = DataLoader(
-        train_dataset,
-        batch_size=batch_size,
-        shuffle=True,
-        num_workers=num_workers,
-        worker_init_fn=seed_worker,
-        generator=torch.Generator().manual_seed(42)
+            train_dataset, 
+            batch_size=batch_size, 
+            num_workers=num_workers, 
+            worker_init_fn=seed_worker,
+            sampler=train_sampler
     )
     
     val_loader = DataLoader(
-        val_dataset,
-        batch_size=batch_size,
-        shuffle=False,
-        num_workers=num_workers,
-        worker_init_fn=seed_worker,
-        generator=torch.Generator().manual_seed(42)
+            val_dataset, 
+            batch_size=batch_size, 
+            num_workers=num_workers, 
+            worker_init_fn=seed_worker,
+            sampler=val_sampler
     )
     
     return train_loader, val_loader, train_dataset.vocab_size
 
-
-def load_datasets(dataset_names: Union[str, List[str]], batch_size: int = 32) -> List[DatasetSpec]:
+def load_datasets(dataset_names: Union[str, List[str]], batch_size: int = 32, seed: int = 42) -> List[DatasetSpec]:
     """
     Load specified datasets based on input names.
     
@@ -357,10 +365,10 @@ def load_datasets(dataset_names: Union[str, List[str]], batch_size: int = 32) ->
         config = dataset_configs[name]
         
         if name == "shakespeare":
-            train_loader, val_loader, vocab_size = config["loader"](batch_size=batch_size)
+            train_loader, val_loader, vocab_size = config["loader"](batch_size=batch_size, seed=seed)
             config["output_size"] = vocab_size
         else:
-            train_loader, val_loader = config["loader"](batch_size=batch_size)
+            train_loader, val_loader = config["loader"](batch_size=batch_size, seed=seed)
         
         spec = DatasetSpec(
             name=name,

--- a/dml/data.py
+++ b/dml/data.py
@@ -5,6 +5,8 @@ from torch.utils.data import DataLoader, Dataset
 from torchvision import datasets, transforms
 from typing import Any, List, Tuple, Optional, Union
 import os 
+import numpy as np
+import random
 
 @dataclass
 class DatasetSpec:
@@ -18,6 +20,11 @@ class DatasetSpec:
     batch_size: int = 32
     training_iterations: int = 1
     weight: float = 1.0  
+
+def seed_worker(worker_id):
+    worker_seed = torch.initial_seed() % 2**32
+    np.random.seed(worker_seed)
+    random.seed(worker_seed)
 
 def get_mnist_loaders(
     batch_size: int = 32,
@@ -42,8 +49,22 @@ def get_mnist_loaders(
     )
     
     return (
-        DataLoader(train_dataset, batch_size=batch_size, shuffle=True, num_workers=num_workers),
-        DataLoader(val_dataset, batch_size=batch_size, shuffle=False, num_workers=num_workers)
+        DataLoader(
+            train_dataset, 
+            batch_size=batch_size, 
+            shuffle=True, 
+            num_workers=num_workers, 
+            worker_init_fn=seed_worker,
+            generator=torch.Generator().manual_seed(42)
+        ),
+        DataLoader(
+            val_dataset, 
+            batch_size=batch_size, 
+            shuffle=False, 
+            num_workers=num_workers, 
+            worker_init_fn=seed_worker,
+            generator=torch.Generator().manual_seed(42)
+        )
     )
 
 def get_cifar10_loaders(
@@ -69,8 +90,22 @@ def get_cifar10_loaders(
     )
     
     return (
-        DataLoader(train_dataset, batch_size=batch_size, shuffle=True, num_workers=num_workers),
-        DataLoader(val_dataset, batch_size=batch_size, shuffle=False, num_workers=num_workers)
+        DataLoader(
+            train_dataset, 
+            batch_size=batch_size, 
+            shuffle=True, 
+            num_workers=num_workers, 
+            worker_init_fn=seed_worker,
+            generator=torch.Generator().manual_seed(42)
+        ),
+        DataLoader(
+            val_dataset, 
+            batch_size=batch_size, 
+            shuffle=False, 
+            num_workers=num_workers, 
+            worker_init_fn=seed_worker,
+            generator=torch.Generator().manual_seed(42)
+        )
     )
 
 def get_cifar100_loaders(
@@ -99,8 +134,22 @@ def get_cifar100_loaders(
     )
     
     return (
-        DataLoader(train_dataset, batch_size=batch_size, shuffle=True, num_workers=num_workers),
-        DataLoader(val_dataset, batch_size=batch_size, shuffle=False, num_workers=num_workers)
+        DataLoader(
+            train_dataset, 
+            batch_size=batch_size, 
+            shuffle=True, 
+            num_workers=num_workers, 
+            worker_init_fn=seed_worker, 
+            generator=torch.Generator.manual_seed(42)
+        ),
+        DataLoader(
+            val_dataset, 
+            batch_size=batch_size, 
+            shuffle=False, 
+            num_workers=num_workers, 
+            worker_init_fn=seed_worker,
+            generator=torch.Generator().manual_seed(42)
+        )
     )
 
 def get_imagenet_1k_loaders(
@@ -150,7 +199,9 @@ def get_imagenet_1k_loaders(
         batch_size=batch_size,
         shuffle=True,
         num_workers=num_workers,
-        pin_memory=True
+        pin_memory=True,
+        worker_init_fn=seed_worker,
+        generator=torch.Generator().manual_seed(42)
     )
     
     val_loader = DataLoader(
@@ -158,7 +209,9 @@ def get_imagenet_1k_loaders(
         batch_size=batch_size,
         shuffle=False,
         num_workers=num_workers,
-        pin_memory=True
+        pin_memory=True,
+        worker_init_fn=seed_worker,
+        generator=torch.Generator().manual_seed(42)
     )
     
     return train_loader, val_loader
@@ -201,9 +254,6 @@ class ShakespeareDataset(Dataset):
         y = chunk[1:]
         return x, y
     
-
-
-
 def get_shakespeare_loaders(
     text_path: str = './data/shakespeare.txt',
     batch_size: int = 64,
@@ -229,14 +279,18 @@ def get_shakespeare_loaders(
         train_dataset,
         batch_size=batch_size,
         shuffle=True,
-        num_workers=num_workers
+        num_workers=num_workers,
+        worker_init_fn=seed_worker,
+        generator=torch.Generator().manual_seed(42)
     )
     
     val_loader = DataLoader(
         val_dataset,
         batch_size=batch_size,
         shuffle=False,
-        num_workers=num_workers
+        num_workers=num_workers,
+        worker_init_fn=seed_worker,
+        generator=torch.Generator().manual_seed(42)
     )
     
     return train_loader, val_loader, train_dataset.vocab_size

--- a/dml/miners.py
+++ b/dml/miners.py
@@ -38,7 +38,7 @@ from dml.destinations import (
     HuggingFacePushDestination,
     HFChainPushDestination,
 )
-from dml.utils import set_seed, calculate_tree_depth
+from dml.utils import set_seed, calculate_tree_depth, compute_chain_hash
 
 
 LOCAL_STORAGE_PATH = "./checkpoints"
@@ -67,6 +67,7 @@ class BaseMiner(ABC, PushMixin):
             "pushed": False,
             "push_attempts": 0,
             "max_push_attempts": 3,  # Maximum number of push attempts
+            "hash": None,
         }
 
         # Initialize record keeping
@@ -152,14 +153,22 @@ class BaseMiner(ABC, PushMixin):
         finally:
             self._save_push_record()
 
+    def get_hash(self, individual):
+        """Gets the hash of an individual's gene expression"""
+        return compute_chain_hash(save_individual_to_json(individual)['expression'])
+
     def update_best_solution(self, individual, generation):
         """Update the best solution if new one is better"""
         current_fitness = individual.fitness.values[0]
-        if current_fitness > self.best_solution["fitness"]:
+        current_hash = self.get_hash(individual)
+
+        if (current_fitness > self.best_solution["fitness"]) \
+            and (current_hash != self.best_solution["hash"]):
             self.best_solution["individual"] = deepcopy(individual)
             self.best_solution["fitness"] = current_fitness
             self.best_solution["pushed"] = False
             self.best_solution["push_attempts"] = 0
+            self.best_solution["hash"] = current_hash
             logging.info(
                 f"New best solution found at generation {generation} with fitness {current_fitness:.4f}"
             )
@@ -234,18 +243,23 @@ class BaseMiner(ABC, PushMixin):
         self.emigrate_genes(best_gene)
         return self.immigrate_genes()
 
-    def create_baseline_model(self):
-        return BaselineNN(input_size=28 * 28, hidden_size=128, output_size=10).to(
-            self.device
-        )
+    def create_baseline_model(self, dataset_name):
+        return get_model_for_dataset(dataset_name).to(self.device), torch.nn.MSELoss()
 
-    def measure_baseline(self):
-        set_seed(self.seed)
-        train_loader, val_loader = self.load_data()
-        baseline_model = self.create_baseline_model()
-        self.train(baseline_model, train_loader)
-        self.baseline_accuracy = self.evaluate(baseline_model, val_loader)
-        logging.info(f"Baseline model accuracy: {self.baseline_accuracy:.4f}")
+    def measure_baseline(self, datasets):
+        fitness = 0.0
+        for dataset in datasets:
+            model = self.create_baseline_model(dataset.name)
+            try:
+                self.train(model, train_loader=dataset.train_loader)
+                fitness += (
+                    self.evaluate(model, val_loader=dataset.val_loader) * dataset.weight
+                )
+            except Exception as e:
+                logging.error(e)
+                return (0.0,)
+        logging.info(f"Baseline model accuracy: {fitness:.4f}")
+        return (fitness,)
 
     def save_checkpoint(
         self,
@@ -358,23 +372,21 @@ class BaseMiner(ABC, PushMixin):
         )
 
     def mine(self):
-        self.measure_baseline()
         datasets = load_datasets(
-            self.config.Miner.dataset_names, batch_size=self.config.Miner.batch_size
+            self.config.Miner.dataset_names, 
+            batch_size=self.config.Miner.batch_size
         )
+        self.measure_baseline(datasets)
 
         checkpoint_file = os.path.join(LOCAL_STORAGE_PATH, "evolution_checkpoint.pkl")
 
         # Check if checkpoint exists
         if os.path.exists(checkpoint_file):
-            population, hof, best_individual_all_time, start_generation = (
-                self.load_checkpoint(checkpoint_file)
-            )
+            population, hof, best_individual_all_time, start_generation = self.load_checkpoint(checkpoint_file)
             if best_individual_all_time is not None:
                 self.best_solution["individual"] = best_individual_all_time
-                self.best_solution["fitness"] = best_individual_all_time.fitness.values[
-                    0
-                ]
+                self.best_solution["fitness"] = best_individual_all_time.fitness.values[0]
+                self.best_solution["hash"] = self.get_hash(best_individual_all_time)
             logging.info(f"Resuming from generation {start_generation}")
         else:
             population = self.toolbox.population(n=self.config.Miner.population_size)
@@ -400,13 +412,12 @@ class BaseMiner(ABC, PushMixin):
             best_updated = self.update_best_solution(best_in_gen, generation)
 
             # Check if we should attempt a push
-            if (
-                best_updated or not self.last_push_success
-            ) and self.should_attempt_push():
+            if (best_updated or not self.last_push_success) and self.should_attempt_push():
                 self.attempt_push(self.best_solution["individual"], generation)
 
             # Select the next generation individuals
             offspring = self.toolbox.select(population, len(population))
+
             # Clone the selected individuals
             offspring = list(map(self.toolbox.clone, offspring))
 
@@ -415,9 +426,7 @@ class BaseMiner(ABC, PushMixin):
                 if random.random() < 0.5:
                     if i + 1 < len(offspring):
                         child1, child2 = offspring[i], offspring[i + 1]
-                        safe_temp1, safe_temp2 = self.toolbox.clone(
-                            child1
-                        ), self.toolbox.clone(child2)
+                        safe_temp1, safe_temp2 = self.toolbox.clone(child1), self.toolbox.clone(child2)
                         self.toolbox.mate(child1, child2)
 
                         if child1.height > self.config.Miner.gp_tree_height:
@@ -968,9 +977,7 @@ class LossMiner(BaseMiner):
 
     def create_model(self, individual, dataset_name):
         set_seed(self.seed)
-        return get_model_for_dataset(dataset_name), self.toolbox.compile(
-            expr=individual
-        )
+        return get_model_for_dataset(dataset_name).to(self.device), self.toolbox.compile(expr=individual)
 
     @staticmethod
     def safe_evaluate(func, outputs, labels):
@@ -1040,14 +1047,9 @@ class LossMiner(BaseMiner):
                     correct += predicted.eq(targets).sum().item()
         return correct / total
 
-    def create_baseline_model(self):
-        return (
-            BaselineNN(input_size=28 * 28, hidden_size=128, output_size=10).to(
-                self.device
-            ),
-            torch.nn.MSELoss(),
-        )
-
+    def create_baseline_model(self, dataset_name):
+        set_seed(self.seed)
+        return get_model_for_dataset(dataset_name).to(self.device), torch.nn.MSELoss()
 
 class SimpleMiner(BaseMiner):
     def load_data(self):

--- a/dml/miners.py
+++ b/dml/miners.py
@@ -155,7 +155,7 @@ class BaseMiner(ABC, PushMixin):
 
     def get_hash(self, individual):
         """Gets the hash of an individual's gene expression"""
-        return compute_chain_hash(save_individual_to_json(individual)['expression'])
+        return compute_chain_hash(str(individual))
 
     def update_best_solution(self, individual, generation):
         """Update the best solution if new one is better"""

--- a/dml/miners.py
+++ b/dml/miners.py
@@ -374,7 +374,8 @@ class BaseMiner(ABC, PushMixin):
     def mine(self):
         datasets = load_datasets(
             self.config.Miner.dataset_names, 
-            batch_size=self.config.Miner.batch_size
+            batch_size=self.config.Miner.batch_size,
+            seed=self.config.Miner.seed
         )
         self.measure_baseline(datasets)
 

--- a/dml/validators.py
+++ b/dml/validators.py
@@ -143,15 +143,16 @@ class BaseValidator(ABC):
         pass
 
     def evaluate_individual(self, individual, datasets):
+        set_seed(self.seed)
         accuracies = []
         for dataset in datasets:
             model = self.create_model(individual, dataset.name)
-            model[0].to(self.config.device)
+            model[0].to(self.device)
             accuracy = self.evaluate(model, (dataset.train_loader, dataset.val_loader))
             accuracies.append(accuracy)
             del model
 
-        return torch.tensor(accuracies, device=self.config.device)
+        return torch.tensor(accuracies, device=self.device)
 
     def compute_ranks(self, filtered_scores_dict):
         """
@@ -226,7 +227,7 @@ class BaseValidator(ABC):
             if not chain_meta:
                 accuracy_scores[hotkey_address] = torch.zeros(
                     (len(self.config.Validator.dataset_names),),
-                    device=self.config.device,
+                    device=self.device,
                 )
                 continue
 
@@ -243,7 +244,7 @@ class BaseValidator(ABC):
                 if gene is None:
                     accuracy_scores[hotkey_address] = torch.zeros(
                         (len(self.config.Validator.dataset_names),),
-                        device=self.config.device,
+                        device=self.device,
                     )
                     continue
 
@@ -257,7 +258,7 @@ class BaseValidator(ABC):
                     )
                     accuracy_scores[hotkey_address] = torch.zeros(
                         (len(self.config.Validator.dataset_names),),
-                        device=self.config.device,
+                        device=self.device,
                     )
                     continue
 
@@ -295,7 +296,7 @@ class BaseValidator(ABC):
                                 )
                                 accuracy_scores[existing_hotkey] = torch.zeros(
                                     (len(self.config.Validator.dataset_names),),
-                                    device=self.config.device,
+                                    device=self.device,
                                 )
                                 continue
 
@@ -305,7 +306,7 @@ class BaseValidator(ABC):
                                 )
                                 accuracy_scores[hotkey_address] = torch.zeros(
                                     (len(self.config.Validator.dataset_names),),
-                                    device=self.config.device,
+                                    device=self.device,
                                 )
                                 continue
                     else:
@@ -314,7 +315,7 @@ class BaseValidator(ABC):
                         )
                         accuracy_scores[hotkey_address] = torch.zeros(
                             (len(self.config.Validator.dataset_names),),
-                            device=self.config.device,
+                            device=self.device,
                         )
                         continue
 
@@ -324,7 +325,7 @@ class BaseValidator(ABC):
                     )
                     accuracy_scores[hotkey_address] = torch.zeros(
                         (len(self.config.Validator.dataset_names),),
-                        device=self.config.device,
+                        device=self.device,
                     )
                     continue
 
@@ -351,7 +352,7 @@ class BaseValidator(ABC):
                                 )
                                 accuracy_scores[existing_hotkey] = torch.zeros(
                                     (len(self.config.Validator.dataset_names),),
-                                    device=self.config.device,
+                                    device=self.device,
                                 )
                                 logging.info(
                                     f"Existing record by {existing_hotkey} copying from {hotkey_address}. Fixing."
@@ -359,7 +360,7 @@ class BaseValidator(ABC):
                             else:
                                 accuracy_scores[hotkey_address] = torch.zeros(
                                     (len(self.config.Validator.dataset_names),),
-                                    device=self.config.device,
+                                    device=self.device,
                                 )
                                 logging.info(
                                     f"Existing record by {hotkey_address} is a duplicate "
@@ -376,13 +377,13 @@ class BaseValidator(ABC):
                     )
                     accuracy_scores[hotkey_address] = torch.zeros(
                         (len(self.config.Validator.dataset_names),),
-                        device=self.config.device,
+                        device=self.device,
                     )
 
                 # Keep cached score
                 logging.info(f"{hotkey_address} using cached score")
                 accuracy_scores[hotkey_address] = torch.tensor(
-                    existing_record["performance"], device=self.config.device
+                    existing_record["performance"], device=self.device
                 )
 
         # Process all genes and check for duplicates
@@ -410,7 +411,7 @@ class BaseValidator(ABC):
                             )
                             accuracy_scores[hotkey_address] = torch.zeros(
                                 (len(self.config.Validator.dataset_names),),
-                                device=self.config.device,
+                                device=self.device,
                             )
                         else:
                             # Evaluate original/unique submissions
@@ -647,7 +648,7 @@ class LossValidator(BaseValidator):
 
     def create_model(self, individual, dataset_name):
 
-        return get_model_for_dataset(dataset_name), self.toolbox.compile(
+        return get_model_for_dataset(dataset_name).to_device(self.device), self.toolbox.compile(
             expr=individual
         )
 

--- a/dml/validators.py
+++ b/dml/validators.py
@@ -147,7 +147,6 @@ class BaseValidator(ABC):
         accuracies = []
         for dataset in datasets:
             model = self.create_model(individual, dataset.name)
-            model[0].to(self.device)
             accuracy = self.evaluate(model, (dataset.train_loader, dataset.val_loader))
             accuracies.append(accuracy)
             del model
@@ -647,8 +646,8 @@ class LossValidator(BaseValidator):
         return train_loader, val_loader
 
     def create_model(self, individual, dataset_name):
-
-        return get_model_for_dataset(dataset_name).to_device(self.device), self.toolbox.compile(
+        set_seed(self.seed)
+        return get_model_for_dataset(dataset_name).to(self.device), self.toolbox.compile(
             expr=individual
         )
 

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -43,9 +43,9 @@ Edit the config files in the configs/ folder to set the following configurations
 - Miner Config:
 - Good luck ! Hyperparameter optimization here might help performance
 
-### 4. Register Metadata (Miner only)
+### ~~4. Register Metadata (Miner only) [Deprecated]~~
 
-Run the following script to register your Hugging Face repository to the chain:
+~~Run the following script to register your Hugging Face repository to the chain:~~
 
 ```
 python register_miner.py

--- a/tests/test_determinism.py
+++ b/tests/test_determinism.py
@@ -1,0 +1,65 @@
+import unittest
+from dml.ops import create_pset_validator
+from dml.gene_io import safe_eval
+from dml.gp_fix import SafePrimitiveTree
+from dml.deap_individual import Individual
+from deap import creator, gp, base, tools
+from dml.utils import set_seed
+from dml.configs.config import config
+from dml.data import load_datasets
+from dml.validators import ValidatorFactory
+from dml.chain.btt_connector import BittensorNetwork
+from dml.chain.chain_manager import ChainManager
+import numpy as np
+
+class TestDeterminism(unittest.TestCase):
+    def test_evaluation(self, seed=42):
+        """
+        Ensures that scoring is consistent across validators
+        """
+        # Initialize DEAP
+        pset = create_pset_validator()
+        creator.create("FitnessMax", base.Fitness, weights=(1.0,))
+        creator.create("Individual", gp.PrimitiveTree, fitness=creator.FitnessMax)
+
+        toolbox = base.Toolbox()
+        toolbox.register("expr", gp.genHalfAndHalf, pset=pset, min_=1, max_=3)
+        toolbox.register("individual", tools.initIterate, creator.Individual, toolbox.expr)
+        toolbox.register("population", tools.initRepeat, list, toolbox.individual)
+        toolbox.register("compile", gp.compile, pset=pset)
+
+        # Initialize validators
+        bt_config = config.get_bittensor_config()
+        BittensorNetwork.initialize(bt_config)
+        config.bittensor_network = BittensorNetwork
+        config.chain_manager = ChainManager(
+            subtensor=BittensorNetwork.subtensor,
+            subnet_uid=bt_config.netuid,
+            wallet=BittensorNetwork.wallet,
+        )
+        validator1 = ValidatorFactory.get_validator(config)
+        validator2 = ValidatorFactory.get_validator(config)
+
+        # Load data
+        set_seed(seed)
+        datasets = load_datasets(config.Validator.dataset_names, batch_size=32, seed=seed)
+
+        # Compile and evaluate test genes
+        loss1 = 'square(safe_sub(x, y))'
+        loss2 = 'cube(safe_sub(x, y))'
+        gene1 = Individual(SafePrimitiveTree.from_string(loss1, pset, safe_eval))
+        gene2 = Individual(SafePrimitiveTree.from_string(loss2, pset, safe_eval))
+
+        # Validator 1's scores
+        val1_fitness1 = validator1.evaluate_individual(gene1, datasets).cpu().detach().numpy()
+        val1_fitness2 = validator1.evaluate_individual(gene2, datasets).cpu().detach().numpy()
+
+        # Validator 2's scores
+        val2_fitness2 = validator2.evaluate_individual(gene2, datasets).cpu().detach().numpy()
+        val2_fitness1 = validator2.evaluate_individual(gene1, datasets).cpu().detach().numpy()
+
+        self.assertTrue(np.allclose(val1_fitness1, val2_fitness1))
+        self.assertTrue(np.allclose(val1_fitness2, val2_fitness2))
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Couple of small changes:

1. Fixed random seeding of validators before model initializations, and improved seed handling in data loaders with multiple processes. This should make evaluations of the same gene fully deterministic across validators and reduce inconsistencies in scoring due to sampling/weight initialization of models
3. Ensure models are on same device as data (otherwise will throw error for GPU users)
4. Added logic to handle edge case for miners where they may end up pushing the same gene again due to sampling. Checks the hash of previous best solution and now pushes only if it is new
5. Update baseline/benchmark model to handle multi-datasets

**Please test before merge.**